### PR TITLE
adds /customresponse/<base64> endpoint to generate custom responses

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -48,6 +48,7 @@ from .helpers import (
     parse_multi_value_header,
     next_stale_after_value,
     digest_challenge_response,
+    custom_response,
 )
 from .utils import weighted_choice
 from .structures import CaseInsensitiveDict
@@ -1401,6 +1402,19 @@ def cache_control(value):
     response = view_get()
     response.headers["Cache-Control"] = "public, max-age={0}".format(value)
     return response
+
+
+@app.route("/customresponse/<base64_customresponse>", methods=["GET", "POST", "PUT", "DELETE", "PATCH", "TRACE"])
+def customresponse(base64_customresponse):
+    """Return custom response specified as base64 encoded json in the URI.
+    ---
+    tags:
+      - Response formats
+    parameters:
+      - in: path
+        name: base64_customresponse
+    """
+    return custom_response(base64_customresponse)
 
 
 @app.route("/encoding/utf8")

--- a/httpbin/helpers.py
+++ b/httpbin/helpers.py
@@ -255,6 +255,33 @@ def status_code(code):
     return r
 
 
+def custom_response(base64_customresponse):
+    """Returns response object of given custom response."""
+    base64_customresponse += "=" * ((4 - len(base64_customresponse) % 4) % 4)
+    customresponse_str = base64.urlsafe_b64decode(base64_customresponse)
+    customresponse = json.loads(customresponse_str)
+    
+    if not isinstance(customresponse,dict):
+        raise ValueError('decoded base64_customresponse does not convert to dict')
+
+    r = make_response()
+
+    if 'status_code' in customresponse:
+        r.status_code = customresponse['status_code']
+    else:
+        r.status_code = 200
+    if 'data' in customresponse:
+        r.data = customresponse['data']
+    elif 'b64data' in customresponse:
+        b64data = customresponse['b64data']
+        b64data += "=" * ((4 - len(b64data) % 4) % 4)
+        r.data = base64.urlsafe_b64decode(b64data)
+    if 'headers' in customresponse:
+        r.headers = customresponse['headers']
+
+    return r
+
+
 def check_basic_auth(user, passwd):
     """Checks user authentication using HTTP Basic Auth."""
 

--- a/httpbin/templates/httpbin.1.html
+++ b/httpbin/templates/httpbin.1.html
@@ -30,6 +30,7 @@
 <li><a href="{{ url_for('view_brotli_encoded_content') }}" data-bare-link="true"><code>/brotli</code></a> Returns brotli-encoded data.</li>
 <li><a href="{{ url_for('view_status_code', codes='418') }}"><code>/status/:code</code></a> Returns given HTTP Status code.</li>
 <li><a href="{{ url_for('response_headers', **{'Content-Type': 'text/plain; charset=UTF-8', 'Server': 'httpbin'}) }}"><code>/response-headers?key=val</code></a> Returns given response headers.</li>
+<li><a href="{{ url_for('customresponse', **eyJzdGF0dXNfY29kZSI6MjAxLCJkYXRhIjoicGxhaW50ZXh0IGRhdGEiLCAiaGVhZGVycyI6eyJYLUVtcHR5IjoiIiwgIkNvbnRlbnQtdHlwZSI6InRleHQvaHRtbCJ9fQ) }}"><code>/customresponse/base64encodedjson</code></a> Returns given base64 encoded json response definition.</li>
 <li><a href="{{ url_for('redirect_n_times', n=6) }}"><code>/redirect/:n</code></a> 302 Redirects <em>n</em> times.</li>
 <li><a href="{{ url_for('redirect_to', url='http://example.com/') }}"><code>/redirect-to?url=foo</code></a> 302 Redirects to the <em>foo</em> URL.</li>
 <li><a href="{{ url_for('redirect_to', url='http://example.com/', status_code=307) }}"><code>/redirect-to?url=foo&status_code=307</code></a> 307 Redirects to the <em>foo</em> URL.</li>


### PR DESCRIPTION
the endopoint allows to generate a custom response based on the submitted
base64 encoded json.

the response is specified in this json decalartion which is passed to thei
make_response function.
examples:
`{"status_code":200,"data":"plaintext data","headers":{"X-Empty":"", "Content-type":"text/plain"}}`

```sh
cat <<EOF | base64 -w0 | read customresponse
{
"status_code":400,
"b64data":"R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs=",
"headers":{"X-Info":"gif 1x1 white", "Content-type":"image/gif"}
}
EOF
curl -i http://localhost/customresponse/$customresponse
HTTP/1.1 400 BAD REQUEST
Server: gunicorn/19.9.0
Date: Sun, 24 Mar 2019 17:46:00 GMT
Connection: keep-alive
X-Info: gif 1x1 white
Content-type: image/gif
Access-Control-Allow-Origin: *
Access-Control-Allow-Credentials: true
Content-Length: 35

GIF89a,D;
```