### PR TITLE
add environment /tags feature

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -218,6 +218,10 @@ def set_cors_headers(response):
     response.headers["Access-Control-Allow-Origin"] = request.headers.get("Origin", "*")
     response.headers["Access-Control-Allow-Credentials"] = "true"
 
+    for k, v in os.environ.items():
+        if k.startswith('XHTTPBIN_'):
+            response.headers[k[9:].replace('_','-')] = v
+
     if request.method == "OPTIONS":
         # Both of these headers are only used for the "preflight request"
         # http://www.w3.org/TR/cors/#access-control-allow-methods-response-header
@@ -297,7 +301,53 @@ def view_deny_page():
     # return "YOU SHOULDN'T BE HERE"
 
 
-@app.route("/ip")
+@app.route('/tags/get/<tag>')
+def view_tag(tag=None):
+    """Returns the requested server's environmnet tag.
+    ---
+    tags:
+      - Response inspection
+    parameters:
+      - in: path
+        name: tag
+        type: string
+    produces:
+      - application/json
+    responses:
+      200:
+        description: The server's environmnet tag and value.
+      404:
+        description: The server's environmnet tag was not found.
+    """
+    if not os.environ.get(f"HTTPBIN_{tag}"):
+        return Response(response="{}", status=404, mimetype="application/json")
+
+    return jsonify( {f"{tag}" : os.environ.get(f"HTTPBIN_{tag}")} )
+
+
+@app.route('/tags')
+def view_tags():
+    """Returns the server's environmnet tags.
+    ---
+    tags:
+      - Response inspection
+    produces:
+      - application/json
+    responses:
+      200:
+        description: The server's environmnet tags.
+      404:
+        description: No server's environmnet tag where found.
+    """
+    tags = dict([ [k[8:],v] for k,v in os.environ.items() if k.startswith("HTTPBIN_") ])
+
+    if not tags:
+        return Response(response="{}", status=404, mimetype="application/json")
+
+    return jsonify(tags)
+
+
+@app.route('/ip')
 def view_origin():
     """Returns the requester's IP Address.
     ---

--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -319,10 +319,10 @@ def view_tag(tag=None):
       404:
         description: The server's environmnet tag was not found.
     """
-    if not os.environ.get(f"HTTPBIN_{tag}"):
+    if not os.environ.get("HTTPBIN_%s" % tag):
         return Response(response="{}", status=404, mimetype="application/json")
 
-    return jsonify( {f"{tag}" : os.environ.get(f"HTTPBIN_{tag}")} )
+    return jsonify( {"%s" % tag : os.environ.get("HTTPBIN_%s" % tag)} )
 
 
 @app.route('/tags')

--- a/test_httpbin.py
+++ b/test_httpbin.py
@@ -812,43 +812,38 @@ class HttpbinTestCase(unittest.TestCase):
         self.assertEqual(parse_multi_value_header('W/"xyzzy", W/"r2d2xxxx", W/"c3piozzzz"'), [ "xyzzy", "r2d2xxxx", "c3piozzzz" ])
         self.assertEqual(parse_multi_value_header('*'), [ "*" ])
 
-    @_setenv("XHTTPBIN_X_Tag_Name", "Tag Value")
-    @_setenv("XHTTPBIN_X_Other-Tag", "Other Value")
     def test_tags_get_header_tags(self):
-        response = self.app.open('/get')
-        self.assertEqual(response.headers.get('X-Tag-Name'), 'Tag Value')
-        self.assertEqual(response.headers.get('X-Other-Tag'), 'Other Value')
+        with _setenv("XHTTPBIN_X_Tag_Name", "Tag Value"), _setenv("XHTTPBIN_X_Other-Tag", "Other Value"):
+            response = self.app.open('/get')
+            self.assertEqual(response.headers.get('X-Tag-Name'), 'Tag Value')
+            self.assertEqual(response.headers.get('X-Other-Tag'), 'Other Value')
 
-    @_setenv("XHTTPBIN_X_Tag_Name", "Tag Value")
-    @_setenv("HTTPBIN_GetTag_Name", "GetTag Value")
-    @_setenv("HTTPBIN_Another-Tag", "Another-Tag Value")
     def test_tags_get_all_tags(self):
-        response = self.app.open('/tags')
-        self.assertEqual(response.headers.get('X-Tag-Name'), 'Tag Value')
-        self.assertEqual(json.loads(response.data.decode('utf-8'))['GetTag_Name'], 'GetTag Value')
-        self.assertEqual(json.loads(response.data.decode('utf-8'))['Another-Tag'], 'Another-Tag Value')
+        with _setenv("XHTTPBIN_X_Tag_Name", "Tag Value"), _setenv("HTTPBIN_GetTag_Name", "GetTag Value"), _setenv("HTTPBIN_Another-Tag", "Another-Tag Value"):
+            response = self.app.open('/tags')
+            self.assertEqual(response.headers.get('X-Tag-Name'), 'Tag Value')
+            self.assertEqual(json.loads(response.data.decode('utf-8'))['GetTag_Name'], 'GetTag Value')
+            self.assertEqual(json.loads(response.data.decode('utf-8'))['Another-Tag'], 'Another-Tag Value')
 
-    @_setenv("XHTTPBIN_X_Tag_Name", "Tag Value")
-    @_setenv("HTTPBIN_GetTag_Name", "GetTag Value")
     def test_tags_get_specific_tag(self):
-        response = self.app.open('/tags/get/GetTag_Name')
-        self.assertEqual(response.headers.get('X-Tag-Name'), 'Tag Value')
-        self.assertEqual(json.loads(response.data.decode('utf-8'))['GetTag_Name'], 'GetTag Value')
+        with _setenv("XHTTPBIN_X_Tag_Name", "Tag Value"), _setenv("HTTPBIN_GetTag_Name", "GetTag Value"):
+            response = self.app.open('/tags/get/GetTag_Name')
+            self.assertEqual(response.headers.get('X-Tag-Name'), 'Tag Value')
+            self.assertEqual(json.loads(response.data.decode('utf-8'))['GetTag_Name'], 'GetTag Value')
 
-    @_setenv("XHTTPBIN_X_Tag_Name", "Tag Value")
-    @_setenv("HTTPBIN_GetTag_Name", "GetTag Value")
     def test_tags_get_specific_undefined_tag(self):
-        response = self.app.open('/tags/get/TagDoesNotExist')
-        self.assertEqual(response.headers.get('X-Tag-Name'), 'Tag Value')
-        self.assertEqual(response.status_code, 404)
-        self.assertEqual(json.loads(response.data.decode('utf-8')), {})
+        with _setenv("XHTTPBIN_X_Tag_Name", "Tag Value"), _setenv("HTTPBIN_GetTag_Name", "GetTag Value"):
+            response = self.app.open('/tags/get/TagDoesNotExist')
+            self.assertEqual(response.headers.get('X-Tag-Name'), 'Tag Value')
+            self.assertEqual(response.status_code, 404)
+            self.assertEqual(json.loads(response.data.decode('utf-8')), {})
 
-    @_setenv("XHTTPBIN_X_Tag_Name", "Tag Value")
     def test_tags_get_all_tags_undefined(self):
-        response = self.app.open('/tags')
-        self.assertEqual(response.headers.get('X-Tag-Name'), 'Tag Value')
-        self.assertEqual(response.status_code, 404)
-        self.assertEqual(json.loads(response.data.decode('utf-8')), {})
+        with _setenv("XHTTPBIN_X_Tag_Name", "Tag Value"):
+            response = self.app.open('/tags')
+            self.assertEqual(response.headers.get('X-Tag-Name'), 'Tag Value')
+            self.assertEqual(response.status_code, 404)
+            self.assertEqual(json.loads(response.data.decode('utf-8')), {})
 
 if __name__ == '__main__':
     unittest.main()

--- a/test_httpbin.py
+++ b/test_httpbin.py
@@ -114,10 +114,10 @@ class HttpbinTestCase(unittest.TestCase):
         httpbin.app.debug = True
         self.app = httpbin.app.test_client()
 
-    def test_index(self):   
+    def test_index(self):
         response = self.app.get('/', headers={'User-Agent': 'test'})
         self.assertEqual(response.status_code, 200)
- 
+
     def get_data(self, response):
         if 'get_data' in dir(response):
             return response.get_data()
@@ -811,6 +811,44 @@ class HttpbinTestCase(unittest.TestCase):
         self.assertEqual(parse_multi_value_header('"xyzzy", "r2d2xxxx", "c3piozzzz"'), [ "xyzzy", "r2d2xxxx", "c3piozzzz" ])
         self.assertEqual(parse_multi_value_header('W/"xyzzy", W/"r2d2xxxx", W/"c3piozzzz"'), [ "xyzzy", "r2d2xxxx", "c3piozzzz" ])
         self.assertEqual(parse_multi_value_header('*'), [ "*" ])
+
+    @_setenv("XHTTPBIN_X_Tag_Name", "Tag Value")
+    @_setenv("XHTTPBIN_X_Other-Tag", "Other Value")
+    def test_tags_get_header_tags(self):
+        response = self.app.open('/get')
+        self.assertEqual(response.headers.get('X-Tag-Name'), 'Tag Value')
+        self.assertEqual(response.headers.get('X-Other-Tag'), 'Other Value')
+
+    @_setenv("XHTTPBIN_X_Tag_Name", "Tag Value")
+    @_setenv("HTTPBIN_GetTag_Name", "GetTag Value")
+    @_setenv("HTTPBIN_Another-Tag", "Another-Tag Value")
+    def test_tags_get_all_tags(self):
+        response = self.app.open('/tags')
+        self.assertEqual(response.headers.get('X-Tag-Name'), 'Tag Value')
+        self.assertEqual(json.loads(response.data.decode('utf-8'))['GetTag_Name'], 'GetTag Value')
+        self.assertEqual(json.loads(response.data.decode('utf-8'))['Another-Tag'], 'Another-Tag Value')
+
+    @_setenv("XHTTPBIN_X_Tag_Name", "Tag Value")
+    @_setenv("HTTPBIN_GetTag_Name", "GetTag Value")
+    def test_tags_get_specific_tag(self):
+        response = self.app.open('/tags/get/GetTag_Name')
+        self.assertEqual(response.headers.get('X-Tag-Name'), 'Tag Value')
+        self.assertEqual(json.loads(response.data.decode('utf-8'))['GetTag_Name'], 'GetTag Value')
+
+    @_setenv("XHTTPBIN_X_Tag_Name", "Tag Value")
+    @_setenv("HTTPBIN_GetTag_Name", "GetTag Value")
+    def test_tags_get_specific_undefined_tag(self):
+        response = self.app.open('/tags/get/TagDoesNotExist')
+        self.assertEqual(response.headers.get('X-Tag-Name'), 'Tag Value')
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(json.loads(response.data.decode('utf-8')), {})
+
+    @_setenv("XHTTPBIN_X_Tag_Name", "Tag Value")
+    def test_tags_get_all_tags_undefined(self):
+        response = self.app.open('/tags')
+        self.assertEqual(response.headers.get('X-Tag-Name'), 'Tag Value')
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(json.loads(response.data.decode('utf-8')), {})
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This feature adds a `/tags` endpoint. The new endpoint retruns environment variables if they start with `HTTPBIN_`.
In addition if environment variables which start with `XHTTPBIN_` exist, they are added as HTTP response headers.


Examples:
Assuming the following environment variables are set:
- `XHTTPBIN_X_TagHeader="Header Value"`
- `HTTPBIN_Tag=Value`
- `HTTPBIN_AnotherTag="long value..."`

```sh
> curl -i http://localhost/tags
HTTP/1.1 200 OK
Content-Type: application/json
Content-Length: 55
Access-Control-Allow-Origin: *
Access-Control-Allow-Credentials: true
X-TagHeader: Header Value
Server: Unit/1.9.0
Date: Sat, 06 Jul 2019 11:53:18 GMT

{
  "AnotherTag": "long value...",
  "Tag": "Value"
}

> curl -i http://localhost/tags/get/Tag
HTTP/1.1 200 OK
Content-Type: application/json
Content-Length: 21
Access-Control-Allow-Origin: *
Access-Control-Allow-Credentials: true
X-TagHeader: Header Value
Server: Unit/1.9.0
Date: Sat, 06 Jul 2019 11:54:40 GMT

{
  "Tag": "Value"
}

> curl -i http://localhost/tags/get/UndefinedTag
HTTP/1.1 404 Not Found
Content-Type: application/json
Content-Length: 2
Access-Control-Allow-Origin: *
Access-Control-Allow-Credentials: true
X-TagHeader: Header Value
Server: Unit/1.9.0
Date: Sat, 06 Jul 2019 11:55:03 GMT

{}

> curl -i http://localhost/get
HTTP/1.1 200 OK
Content-Type: application/json
Content-Length: 179
Access-Control-Allow-Origin: *
Access-Control-Allow-Credentials: true
X-TagHeader: Header Value
Server: Unit/1.9.0
Date: Sat, 06 Jul 2019 11:55:25 GMT

{
  "args": {},
  "headers": {
    "Accept": "*/*",
    "Host": "localhost",
    "User-Agent": "curl/7.54.0"
  },
  "origin": "172.17.0.1",
  "url": "http://localhost/get"
}
```

If no `HTTPBIN_` environment variables exist, the response for `/tags` will look like this:
```sh
> curl -i http://localhost/tags
HTTP/1.1 404 Not Found
Content-Type: application/json
Content-Length: 2
Access-Control-Allow-Origin: *
Access-Control-Allow-Credentials: true
X-TagHeader: Header Value
Server: Unit/1.9.0
Date: Sat, 06 Jul 2019 11:58:07 GMT

{}
```